### PR TITLE
Add All Ideas admin page; trim widget to 5 most recent

### DIFF
--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Ideas Inbox
  * Description: An ideas inbox for your WP dashboard. Drop ideas for your future self to blog about.
- * Version:     0.1.0
+ * Version:     0.2.0
  * Author:      Kelly Hoffman
  * License:     GPL-2.0-or-later
  * Text Domain: ideas-dashboard-widget
@@ -12,10 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const IDEAS_INBOX_META_KEY = 'ideas_inbox';
-const IDEAS_INBOX_NONCE    = 'ideas_inbox';
+const IDEAS_INBOX_META_KEY  = 'ideas_inbox';
+const IDEAS_INBOX_NONCE     = 'ideas_inbox';
+const IDEAS_INBOX_PAGE_SLUG = 'ideas-inbox';
 
 add_action( 'wp_dashboard_setup', 'ideas_inbox_register_widget' );
+add_action( 'admin_menu',         'ideas_inbox_register_page' );
 add_action( 'admin_post_ideas_inbox_add',    'ideas_inbox_handle_add' );
 add_action( 'admin_post_ideas_inbox_delete', 'ideas_inbox_handle_delete' );
 add_action( 'admin_post_ideas_inbox_draft',  'ideas_inbox_handle_draft' );
@@ -31,6 +33,17 @@ function ideas_inbox_register_widget() {
 	);
 }
 
+function ideas_inbox_register_page() {
+	add_submenu_page(
+		'edit.php',
+		__( 'Ideas Inbox', 'ideas-dashboard-widget' ),
+		__( 'Ideas Inbox', 'ideas-dashboard-widget' ),
+		'edit_posts',
+		IDEAS_INBOX_PAGE_SLUG,
+		'ideas_inbox_render_page'
+	);
+}
+
 function ideas_inbox_get_ideas() {
 	$ideas = get_user_meta( get_current_user_id(), IDEAS_INBOX_META_KEY, true );
 	return is_array( $ideas ) ? $ideas : array();
@@ -41,7 +54,9 @@ function ideas_inbox_save_ideas( array $ideas ) {
 }
 
 function ideas_inbox_render_widget() {
-	$ideas = ideas_inbox_get_ideas();
+	$ideas   = ideas_inbox_get_ideas();
+	$total   = count( $ideas );
+	$visible = array_slice( $ideas, -5, 5, true );
 	?>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-bottom:1em;">
 		<input type="hidden" name="action" value="ideas_inbox_add" />
@@ -63,28 +78,95 @@ function ideas_inbox_render_widget() {
 	<?php if ( empty( $ideas ) ) : ?>
 		<p style="color:#666;"><em><?php esc_html_e( 'No ideas yet. Drop one above.', 'ideas-dashboard-widget' ); ?></em></p>
 	<?php else : ?>
-		<ul style="margin:0;padding:0;list-style:none;">
-			<?php foreach ( array_reverse( $ideas, true ) as $index => $idea ) : ?>
-				<li style="padding:.6em 0;border-top:1px solid #eee;">
-					<div style="white-space:pre-wrap;"><?php echo esc_html( $idea['text'] ); ?></div>
-					<div style="font-size:.85em;color:#666;margin-top:.25em;">
-						<?php
-						/* translators: %s: human-readable time difference, e.g. "3 hours" */
-						echo esc_html( sprintf( __( '%s ago', 'ideas-dashboard-widget' ), human_time_diff( (int) $idea['time'] ) ) );
-						?>
-						&nbsp;·&nbsp;
-						<a href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_draft', $index ) ); ?>">
-							<?php esc_html_e( 'Turn into draft', 'ideas-dashboard-widget' ); ?>
-						</a>
-						&nbsp;·&nbsp;
-						<a href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_delete', $index ) ); ?>" style="color:#b32d2e;">
-							<?php esc_html_e( 'Delete', 'ideas-dashboard-widget' ); ?>
-						</a>
-					</div>
-				</li>
-			<?php endforeach; ?>
-		</ul>
+		<?php ideas_inbox_render_list( array_reverse( $visible, true ) ); ?>
+		<?php if ( $total > 5 ) : ?>
+			<p style="text-align:right;margin:.75em 0 0;">
+				<a href="<?php echo esc_url( add_query_arg( 'page', IDEAS_INBOX_PAGE_SLUG, admin_url( 'edit.php' ) ) ); ?>">
+					<?php
+					/* translators: %d: total number of ideas */
+					echo esc_html( sprintf( __( 'View all ideas (%d) →', 'ideas-dashboard-widget' ), $total ) );
+					?>
+				</a>
+			</p>
+		<?php endif; ?>
 	<?php endif; ?>
+	<?php
+}
+
+function ideas_inbox_render_page() {
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		wp_die( esc_html__( 'You do not have permission to view this page.', 'ideas-dashboard-widget' ) );
+	}
+
+	$ideas        = ideas_inbox_get_ideas();
+	$total        = count( $ideas );
+	$per_page     = 20;
+	$total_pages  = max( 1, (int) ceil( $total / $per_page ) );
+	$paged        = isset( $_GET['paged'] ) ? max( 1, (int) $_GET['paged'] ) : 1;
+	$paged        = min( $paged, $total_pages );
+	$offset       = ( $paged - 1 ) * $per_page;
+	$newest_first = array_reverse( $ideas, true );
+	$page_slice   = array_slice( $newest_first, $offset, $per_page, true );
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Ideas Inbox', 'ideas-dashboard-widget' ); ?></h1>
+
+		<?php if ( empty( $ideas ) ) : ?>
+			<p><em><?php esc_html_e( 'No ideas yet. Head to your dashboard to add one.', 'ideas-dashboard-widget' ); ?></em></p>
+		<?php else : ?>
+			<?php ideas_inbox_render_list( $page_slice ); ?>
+			<?php if ( $total_pages > 1 ) : ?>
+				<div class="tablenav" style="margin-top:1em;">
+					<div class="tablenav-pages">
+						<?php
+						echo paginate_links(
+							array(
+								'base'      => add_query_arg(
+									array(
+										'page'  => IDEAS_INBOX_PAGE_SLUG,
+										'paged' => '%#%',
+									),
+									admin_url( 'edit.php' )
+								),
+								'format'    => '',
+								'current'   => $paged,
+								'total'     => $total_pages,
+								'prev_text' => __( '« Previous', 'ideas-dashboard-widget' ),
+								'next_text' => __( 'Next »', 'ideas-dashboard-widget' ),
+							)
+						);
+						?>
+					</div>
+				</div>
+			<?php endif; ?>
+		<?php endif; ?>
+	</div>
+	<?php
+}
+
+function ideas_inbox_render_list( array $ideas ) {
+	?>
+	<ul style="margin:0;padding:0;list-style:none;">
+		<?php foreach ( $ideas as $index => $idea ) : ?>
+			<li style="padding:.6em 0;border-top:1px solid #eee;">
+				<div style="white-space:pre-wrap;"><?php echo esc_html( $idea['text'] ); ?></div>
+				<div style="font-size:.85em;color:#666;margin-top:.25em;">
+					<?php
+					/* translators: %s: human-readable time difference, e.g. "3 hours" */
+					echo esc_html( sprintf( __( '%s ago', 'ideas-dashboard-widget' ), human_time_diff( (int) $idea['time'] ) ) );
+					?>
+					&nbsp;·&nbsp;
+					<a href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_draft', $index ) ); ?>">
+						<?php esc_html_e( 'Turn into draft', 'ideas-dashboard-widget' ); ?>
+					</a>
+					&nbsp;·&nbsp;
+					<a href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_delete', $index ) ); ?>" style="color:#b32d2e;">
+						<?php esc_html_e( 'Delete', 'ideas-dashboard-widget' ); ?>
+					</a>
+				</div>
+			</li>
+		<?php endforeach; ?>
+	</ul>
 	<?php
 }
 
@@ -109,7 +191,8 @@ function ideas_inbox_verify_request() {
 }
 
 function ideas_inbox_redirect_back() {
-	wp_safe_redirect( admin_url( 'index.php' ) );
+	$referer = wp_get_referer();
+	wp_safe_redirect( $referer ? $referer : admin_url( 'index.php' ) );
 	exit;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,8 @@ This plugin is deliberately small:
 ## Usage
 
 - Type an idea into the textarea and click **Add idea**.
-- Existing ideas appear below in reverse-chronological order.
+- The widget shows your 5 most recent ideas in reverse-chronological order. When you have more than 5, a **View all ideas** link appears at the bottom of the widget.
+- All ideas also live on a dedicated admin screen at **Posts → Ideas Inbox**, paginated 20 at a time.
 - Each idea has two actions:
   - **Turn into draft** — creates a draft post with the idea as the content (and a trimmed title), removes it from the inbox, and opens the post editor.
   - **Delete** — removes the idea from the inbox.


### PR DESCRIPTION
Closes #3.

## Summary

- Dashboard widget now shows the 5 most recent ideas, with a **View all ideas (N) →** link when the total exceeds 5.
- New **Posts → Ideas Inbox** admin page renders the full list, paginated 20 per page with the same *Turn into draft* / *Delete* actions.
- Action handlers now redirect via `wp_get_referer()`, so mutating from the All Ideas page (including deeper pages) lands you back where you were instead of bouncing to the dashboard.

## Design notes

- Mirrors the core dashboard-widget convention (*Activity*, *Quick Draft*): keep the widget glanceable, offload the full list to a dedicated admin screen.
- Storage is unchanged — still one `ideas_inbox` user-meta row per user. "Pagination" is purely presentational (`array_slice` + `paginate_links()`), no new schema.
- `<li>` markup was extracted into `ideas_inbox_render_list()` so the widget and full page can't drift.
- Version bumped `0.1.0` → `0.2.0`.

## Test plan

Try the Playground preview link that'll be posted as a sticky comment below, then:

- [ ] With 0 ideas: widget shows empty state, no "View all" link. `Posts → Ideas Inbox` shows its own empty state.
- [ ] With 1-5 ideas: widget shows all of them, no "View all" link.
- [ ] With 6+ ideas: widget shows 5 most recent + "View all ideas (N) →" link pointing at `Posts → Ideas Inbox`.
- [ ] With 21+ ideas: All Ideas page paginates, 20 per row, with Prev/Next links.
- [ ] Delete on page 2 of All Ideas keeps you on page 2 (not dashboard), unless the page is now empty — in which case you'll land on an adjusted page (the `min( $paged, $total_pages )` clamp handles it).
- [ ] "Turn into draft" from either surface still opens the post editor as before.
- [ ] Nonce + capability checks still enforced (try visiting the page as a user without `edit_posts`).