### PR TITLE
Open ideas as paragraph blocks, not Classic

### DIFF
--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -159,7 +159,7 @@ function ideas_inbox_handle_draft() {
 	$post_id = wp_insert_post(
 		array(
 			'post_title'   => wp_trim_words( $idea['text'], 10, '…' ),
-			'post_content' => $idea['text'],
+			'post_content' => "<!-- wp:paragraph -->\n<p>" . str_replace( "\n", '<br>', esc_html( $idea['text'] ) ) . "</p>\n<!-- /wp:paragraph -->",
 			'post_status'  => 'draft',
 			'post_author'  => get_current_user_id(),
 		),


### PR DESCRIPTION
## Summary
- Turning an idea into a draft used to store the raw text as `post_content`, which the block editor loaded as a Classic block.
- Wrap the text in a `wp:paragraph` block and convert newlines to `<br>` so the draft opens as a ready-to-edit paragraph block.

## Test plan
- [ ] Open the PR's Playground preview link (sticky comment).
- [ ] Drop a short idea in the Ideas Inbox widget, click **Turn into draft**.
- [ ] Confirm the editor opens with a paragraph block containing the idea text (not a Classic block).
- [ ] Repeat with a multi-line idea; confirm line breaks render as `<br>` inside the paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes https://github.com/kellychoffman/ideas-dashboard-widget/issues/2
