### PR TITLE
Fix Playground preview: use git:directory + encodeURI

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -15,7 +15,7 @@ jobs:
         id: url
         env:
           REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           URL=$(node -e '
             const blueprint = {
@@ -25,8 +25,10 @@ jobs:
                 {
                   step: "installPlugin",
                   pluginData: {
-                    resource: "url",
-                    url: `https://github-proxy.com/proxy/?repo=${process.env.REPO}&pr=${process.env.PR}`
+                    resource: "git:directory",
+                    url: `https://github.com/${process.env.REPO}`,
+                    ref: process.env.HEAD_REF,
+                    refType: "branch"
                   },
                   options: { activate: true }
                 }
@@ -34,7 +36,7 @@ jobs:
             };
             process.stdout.write(
               "https://playground.wordpress.net/#" +
-              encodeURIComponent(JSON.stringify(blueprint))
+              encodeURI(JSON.stringify(blueprint))
             );
           ')
           echo "url=$URL" >> "$GITHUB_OUTPUT"

--- a/blueprint.json
+++ b/blueprint.json
@@ -6,8 +6,10 @@
 		{
 			"step": "installPlugin",
 			"pluginData": {
-				"resource": "url",
-				"url": "https://github-proxy.com/proxy/?repo=kellychoffman/ideas-dashboard-widget&branch=main"
+				"resource": "git:directory",
+				"url": "https://github.com/kellychoffman/ideas-dashboard-widget",
+				"ref": "main",
+				"refType": "branch"
 			},
 			"options": {
 				"activate": true


### PR DESCRIPTION
## Summary
The sticky Playground preview link on every PR is currently broken. Two compounding issues:

1. **`github-proxy.com` is unreachable** — TCP connections to `64.225.49.234` time out. The blueprint and workflow both depend on it to fetch the plugin zip from GitHub.
2. **Even after switching to Playground's native `git:directory` resource, the URL was still rejected as `Invalid blueprint`** — because the workflow used `encodeURIComponent`, but Playground's URL parser uses `decodeURI` on the hash. `decodeURI` does *not* decode `%3A`, `%2C`, `%2F`, so `:`, `,`, and `/` survived as literal escape sequences and `JSON.parse` failed.

This PR:
- Switches `blueprint.json` and the `playground-preview.yml` workflow off `github-proxy.com` and onto Playground's built-in `git:directory` resource (no third-party hop).
- Drops the `.git` suffix from the GitHub URL (Playground rejects it).
- Replaces `encodeURIComponent` with `encodeURI` so the hash survives Playground's `decodeURI` round-trip.
- Updates the workflow to pass `pull_request.head.ref` (branch name) instead of the PR number, matching the new resource shape.

The sticky comment on this PR itself is the live verification — if it loads, the fix works.

## Test plan
- [ ] CI generates a sticky Playground preview comment.
- [ ] Click the link; Playground boots with the Ideas Inbox widget on the dashboard.
- [ ] Try the same on PR #4 once this is merged + that branch gets a fresh push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)