### PR TITLE
Playground preview: fix for fork PRs

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build Playground URL for this PR
         id: url
         env:
-          REPO: ${{ github.repository }}
+          REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           URL=$(node -e '


### PR DESCRIPTION
## Summary
Follow-up to #7. The Playground workflow built the git URL from \`github.repository\`, which is always the upstream repo. For PRs opened from forks (e.g. #6), the branch lives on the contributor's fork — Playground then 404s with \`Git ref "refs/heads/<branch>" not found\`.

Switch to \`github.event.pull_request.head.repo.full_name\`, which:
- Equals \`github.repository\` for same-repo PRs (no behavior change there).
- Points at the contributor's fork for fork PRs.

## Test plan
- [ ] Sticky comment on this PR works (same-repo verification).
- [ ] Once merged, push to PR #6's branch (fork PR) and confirm the regenerated sticky link loads in Playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)