### PR TITLE
Polish View all ideas link and All Ideas page pagination

### DIFF
--- a/assets/ideas-inbox.css
+++ b/assets/ideas-inbox.css
@@ -120,6 +120,32 @@
 	font-size: var( --wpds-typography-font-size-xs, 12px );
 }
 
+.ideas-inbox__view-all a {
+	color: var( --wpds-color-fg-content-neutral-weak, #50575e );
+	font-weight: var( --wpds-typography-font-weight-medium, 500 );
+	text-decoration: none;
+	border-radius: var( --wpds-border-radius-sm, 2px );
+	padding: 2px 4px;
+	margin: 0 -4px;
+}
+
+.ideas-inbox__view-all a:hover {
+	color: var( --wpds-color-fg-interactive-brand, var( --wp-admin-theme-color, #3858e9 ) );
+	text-decoration: underline;
+}
+
+.ideas-inbox__view-all a:focus {
+	outline: none;
+	color: var( --wpds-color-fg-interactive-brand, var( --wp-admin-theme-color, #3858e9 ) );
+	box-shadow: 0 0 0 var( --wpds-border-width-focus, 2px ) var( --wpds-color-stroke-focus-brand, var( --wp-admin-theme-color, #3858e9 ) );
+}
+
+/* Pagination on the All Ideas admin page */
+
+.ideas-inbox__pagination {
+	margin-top: var( --wpds-dimension-gap-md, 16px );
+}
+
 /* Icon-only destructive action. Uses dashicons inside. */
 
 .ideas-inbox__delete {

--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -170,7 +170,7 @@ function ideas_inbox_render_page() {
 		<?php else : ?>
 			<?php ideas_inbox_render_list( $page_slice ); ?>
 			<?php if ( $total_pages > 1 ) : ?>
-				<div class="tablenav">
+				<div class="tablenav ideas-inbox__pagination">
 					<div class="tablenav-pages">
 						<?php
 						echo paginate_links(


### PR DESCRIPTION
## Summary

Tightens the two spots that the [#6](https://github.com/kellychoffman/ideas-dashboard-widget/pull/6) WPDS pass didn't fully reach: the **View all ideas (N) →** link on the dashboard widget and the pagination on the **Posts → Ideas Inbox** admin page.

- The View all link was rendering with the default wp-admin blue + underline, which reads louder than anything else in the widget. Gave the anchor a neutral-weak resting color at medium weight with no default underline, brand color + underline on hover, and a real focus ring keyed to `--wpds-color-stroke-focus-brand` (with `--wp-admin-theme-color` as a fallback so it follows the admin color scheme on pre-WPDS versions).
- Added `.ideas-inbox__pagination` on the All Ideas page's `tablenav` so the Prev/Next links get token-based top spacing (`--wpds-dimension-gap-md`) instead of sitting flush against the last row.

No markup reshuffling on the widget — just the anchor inside an existing wrapper. The admin-page change is a single extra class on the existing `tablenav` div, so core pagination styling continues to apply.

## Test plan

- [ ] Open the Playground preview from the sticky PR comment.
- [ ] **Dashboard widget with 6+ ideas:** the View all link is no longer standard-blue underlined. Hover it → brand color + underline. Tab to it → visible focus ring. Click → lands on `Posts → Ideas Inbox`.
- [ ] Switch admin color scheme (Profile → Admin Color Scheme) and confirm the link's hover/focus color tracks the scheme.
- [ ] **Posts → Ideas Inbox with 21+ ideas:** Prev/Next pagination has clear breathing room above the last row. On a single-page list (≤20 ideas), no pagination shows (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)