### PR TITLE
Add ConfirmDialog-based delete confirmation

### DIFF
--- a/assets/ideas-inbox.js
+++ b/assets/ideas-inbox.js
@@ -1,0 +1,102 @@
+/**
+ * Ideas Inbox — client-side progressive enhancement.
+ *
+ * Replaces the inline `confirm()` fallback on the Delete link with a
+ * WPDS ConfirmDialog for a friendlier confirmation experience.
+ */
+
+( function () {
+	'use strict';
+
+	if ( typeof wp === 'undefined' || ! wp.components || ! wp.element || ! wp.i18n ) {
+		return;
+	}
+
+	var ConfirmDialog = wp.components.__experimentalConfirmDialog;
+	var createElement = wp.element.createElement;
+	var createRoot    = wp.element.createRoot;
+	var useState      = wp.element.useState;
+	var useEffect     = wp.element.useEffect;
+	var useCallback   = wp.element.useCallback;
+	var __            = wp.i18n.__;
+
+	if ( ! ConfirmDialog || ! createRoot ) {
+		return;
+	}
+
+	var DIALOG_EVENT = 'ideas-inbox:confirm-delete';
+
+	function DeleteConfirm() {
+		var state    = useState( null );
+		var pending  = state[ 0 ];
+		var setPending = state[ 1 ];
+
+		useEffect( function () {
+			function onRequest( event ) {
+				setPending( event.detail.url );
+			}
+			document.addEventListener( DIALOG_EVENT, onRequest );
+			return function () {
+				document.removeEventListener( DIALOG_EVENT, onRequest );
+			};
+		}, [] );
+
+		var close = useCallback( function () {
+			setPending( null );
+		}, [] );
+
+		return createElement(
+			ConfirmDialog,
+			{
+				isOpen: pending !== null,
+				confirmButtonText: __( 'Delete', 'ideas-dashboard-widget' ),
+				cancelButtonText: __( 'Never mind', 'ideas-dashboard-widget' ),
+				onConfirm: function () {
+					var url = pending;
+					setPending( null );
+					if ( url ) {
+						window.location.href = url;
+					}
+				},
+				onCancel: close,
+			},
+			__( "Just double checking you want to delete this idea. It can't be undone.", 'ideas-dashboard-widget' )
+		);
+	}
+
+	function init() {
+		// Mount the dialog portal outside the dashboard widget so it
+		// isn't clipped by postbox overflow rules.
+		var container = document.createElement( 'div' );
+		container.className = 'ideas-inbox-dialog-root';
+		document.body.appendChild( container );
+		createRoot( container ).render( createElement( DeleteConfirm ) );
+
+		// Strip the native confirm() fallback now that the component
+		// dialog is ready. Links without JS keep the inline handler.
+		document.querySelectorAll( '.ideas-inbox__delete[onclick]' ).forEach( function ( link ) {
+			link.removeAttribute( 'onclick' );
+		} );
+
+		// Delegate click handling so it also covers any links added
+		// to the DOM later in this page load.
+		document.addEventListener( 'click', function ( event ) {
+			var link = event.target.closest( '.ideas-inbox__delete' );
+			if ( ! link ) {
+				return;
+			}
+			event.preventDefault();
+			document.dispatchEvent(
+				new CustomEvent( DIALOG_EVENT, {
+					detail: { url: link.href },
+				} )
+			);
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Ideas Inbox
  * Description: An ideas inbox for your WP dashboard. Drop ideas for your future self to blog about.
- * Version:     0.2.0
+ * Version:     0.3.0
  * Author:      Kelly Hoffman
  * License:     GPL-2.0-or-later
  * Text Domain: ideas-dashboard-widget
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const IDEAS_INBOX_VERSION   = '0.2.0';
+const IDEAS_INBOX_VERSION   = '0.3.0';
 const IDEAS_INBOX_META_KEY  = 'ideas_inbox';
 const IDEAS_INBOX_NONCE     = 'ideas_inbox';
 const IDEAS_INBOX_PAGE_SLUG = 'ideas-inbox';
@@ -33,12 +33,21 @@ function ideas_inbox_enqueue_assets( $hook ) {
 		return;
 	}
 	wp_enqueue_style( 'dashicons' );
+	wp_enqueue_style( 'wp-components' );
 	wp_enqueue_style(
 		'ideas-inbox',
 		plugins_url( 'assets/ideas-inbox.css', __FILE__ ),
-		array( 'dashicons' ),
+		array( 'dashicons', 'wp-components' ),
 		IDEAS_INBOX_VERSION
 	);
+	wp_enqueue_script(
+		'ideas-inbox',
+		plugins_url( 'assets/ideas-inbox.js', __FILE__ ),
+		array( 'wp-components', 'wp-element', 'wp-i18n' ),
+		IDEAS_INBOX_VERSION,
+		true
+	);
+	wp_set_script_translations( 'ideas-inbox', 'ideas-dashboard-widget' );
 }
 
 function ideas_inbox_register_widget() {


### PR DESCRIPTION
## Summary

Replaces the inline `confirm()` fallback on the Delete link with a real WPDS **ConfirmDialog** component so destructive actions feel intentional and match the rest of the admin's visual language.

- New `assets/ideas-inbox.js` mounts a small React app that renders `@wordpress/components`' `ConfirmDialog` (via `wp.components.__experimentalConfirmDialog`) and intercepts clicks on `.ideas-inbox__delete` anchors. On confirm, the existing nonce-protected delete URL is navigated to; on cancel, the dialog just closes.
- `ideas_inbox_enqueue_assets()` now also enqueues `wp-components` (CSS + JS), `wp-element`, and `wp-i18n` so the component and its styles are available on the dashboard and on the Ideas Inbox admin page.
- The inline `onclick="return confirm(...)"` on the Delete link is kept in PHP as a no-JS fallback; the JS strips it when the component is ready so users never see two dialogs.
- Copy: _"Just double checking you want to delete this idea. It can't be undone."_ with **Never mind** / **Delete** buttons.
- No custom styling for the dialog — we use the stock `ConfirmDialog` appearance.
- Plugin version + `IDEAS_INBOX_VERSION` bumped to `0.3.0` so the asset cache-busters take effect.

## Test plan

- [ ] Open the Playground preview from the sticky PR comment.
- [ ] On `/wp-admin/index.php`, add an idea and click the 🗑 icon on the row. Confirm that a WPDS modal appears (not a native browser prompt) with the new copy and **Never mind** / **Delete** buttons.
- [ ] Click **Never mind** — dialog closes, idea stays in the list.
- [ ] Click **Delete** — dialog closes, idea is removed, page reloads to the dashboard.
- [ ] Add 6+ ideas, then navigate to **Posts → Ideas Inbox**. Delete from the full page and confirm the same ConfirmDialog behavior works there.
- [ ] Disable JS in devtools and reload. Clicking 🗑 should fall back to the native `confirm()` prompt.
- [ ] Tab through the dialog — focus should be trapped inside it, and `Esc` should close it (inherited ConfirmDialog behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Human edit: Fixes https://github.com/kellychoffman/ideas-dashboard-widget/issues/9
