### PR TITLE
Playground preview: post sticky comment on fork PRs

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,7 +1,7 @@
 name: Playground preview
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary

The Playground preview's sticky comment has been failing on every PR from a fork — including all of #6's runs and #11's first run — with **Resource not accessible by integration** on the comment step. It's been working for branches pushed directly to this repo, which is why it wasn't obvious.

Root cause: the workflow uses `on: pull_request`. For PRs opened from a fork, GitHub hard-codes `GITHUB_TOKEN` to read-only regardless of the `permissions:` block, so the `pull-requests: write` declaration is effectively ignored and the POST to create a comment is refused.

Switching to `on: pull_request_target` runs the workflow in the base repo's context, where the declared `pull-requests: write` permission is honored for fork PRs.

## Safety

`pull_request_target` is only dangerous when a workflow checks out and executes untrusted code from the fork. This workflow doesn't — it reads only event metadata (`github.event.pull_request.head.repo.full_name`, `github.event.pull_request.head.ref`) and runs a small hardcoded inline node script to build the URL. There is no `actions/checkout`, no `npm install`, no PR-authored code is executed. Switching triggers does not change the blast radius.

## Test plan

- [ ] Merge this PR.
- [ ] Push a new commit to #11 (`annezazu:wpds-all-ideas-polish`) and confirm the sticky comment now appears and updates on subsequent pushes.
- [ ] Open a fresh PR from a fork and confirm the first-run comment posts.
- [ ] Confirm upstream-branch PRs still get the comment (trigger should work for both fork and non-fork PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)