### PR TITLE
Add/delete ideas without a full page reload

### DIFF
--- a/assets/ideas-inbox.css
+++ b/assets/ideas-inbox.css
@@ -212,3 +212,13 @@
 	margin: 0;
 	font-size: var( --wpds-typography-font-size-xs, 12px );
 }
+
+/* Inline error notice shown when a REST call fails. */
+
+.ideas-inbox__notice {
+	margin: 0 0 var( --wpds-dimension-gap-md, 16px );
+}
+
+.ideas-inbox__notice p {
+	margin: 0.5em 0;
+}

--- a/assets/ideas-inbox.js
+++ b/assets/ideas-inbox.js
@@ -15,11 +15,10 @@
 ( function () {
 	'use strict';
 
-	if ( typeof wp === 'undefined' || ! wp.components || ! wp.element || ! wp.i18n ) {
+	if ( typeof wp === 'undefined' || ! wp.element || ! wp.i18n ) {
 		return;
 	}
 
-	var ConfirmDialog = wp.components.__experimentalConfirmDialog;
 	var createElement = wp.element.createElement;
 	var createRoot    = wp.element.createRoot;
 	var useState      = wp.element.useState;
@@ -29,9 +28,11 @@
 	var _n            = wp.i18n._n;
 	var apiFetch      = wp.apiFetch;
 
-	if ( ! ConfirmDialog || ! createRoot ) {
-		return;
-	}
+	// The delete dialog depends on Components; the add flow does not.
+	// Guard them independently so the add-form enhancement still
+	// activates even if __experimentalConfirmDialog is renamed or removed.
+	var ConfirmDialog   = wp.components && wp.components.__experimentalConfirmDialog;
+	var hasDeleteDialog = !! ( ConfirmDialog && createRoot );
 
 	var DIALOG_EVENT = 'ideas-inbox:confirm-delete';
 	var REST_BASE    = '/ideas-inbox/v1/ideas';
@@ -246,7 +247,7 @@
 		}
 
 		apiFetch( {
-			path: REST_BASE + '/' + encodeURIComponent( pending.id ),
+			path: REST_BASE + '/' + pending.id,
 			method: 'DELETE',
 		} ).then( function ( res ) {
 			onDeleteSuccess( container, pending.row, res );
@@ -340,34 +341,36 @@
 	}
 
 	function init() {
-		// Mount the dialog portal outside the dashboard widget so it
-		// isn't clipped by postbox overflow rules.
-		var dialogRoot = document.createElement( 'div' );
-		dialogRoot.className = 'ideas-inbox-dialog-root';
-		document.body.appendChild( dialogRoot );
-		createRoot( dialogRoot ).render( createElement( DeleteConfirm ) );
+		if ( hasDeleteDialog ) {
+			// Mount the dialog portal outside the dashboard widget so it
+			// isn't clipped by postbox overflow rules.
+			var dialogRoot = document.createElement( 'div' );
+			dialogRoot.className = 'ideas-inbox-dialog-root';
+			document.body.appendChild( dialogRoot );
+			createRoot( dialogRoot ).render( createElement( DeleteConfirm ) );
 
-		// Strip the native confirm() fallback now that the component
-		// dialog is ready. Links without JS keep the inline handler.
-		document.querySelectorAll( '.ideas-inbox__delete[onclick]' ).forEach( function ( link ) {
-			link.removeAttribute( 'onclick' );
-		} );
+			// Strip the native confirm() fallback now that the component
+			// dialog is ready. Links without JS keep the inline handler.
+			document.querySelectorAll( '.ideas-inbox__delete[onclick]' ).forEach( function ( link ) {
+				link.removeAttribute( 'onclick' );
+			} );
 
-		// Delegate delete click handling (also covers rows inserted later).
-		document.addEventListener( 'click', function ( event ) {
-			var link = event.target.closest( '.ideas-inbox__delete' );
-			if ( ! link ) {
-				return;
-			}
-			event.preventDefault();
-			var row = link.closest( '.ideas-inbox__row' );
-			var id  = row ? row.getAttribute( 'data-id' ) : '';
-			document.dispatchEvent(
-				new CustomEvent( DIALOG_EVENT, {
-					detail: { url: link.href, id: id, row: row },
-				} )
-			);
-		} );
+			// Delegate delete click handling (also covers rows inserted later).
+			document.addEventListener( 'click', function ( event ) {
+				var link = event.target.closest( '.ideas-inbox__delete' );
+				if ( ! link ) {
+					return;
+				}
+				event.preventDefault();
+				var row = link.closest( '.ideas-inbox__row' );
+				var id  = row ? row.getAttribute( 'data-id' ) : '';
+				document.dispatchEvent(
+					new CustomEvent( DIALOG_EVENT, {
+						detail: { url: link.href, id: id, row: row },
+					} )
+				);
+			} );
+		}
 
 		document.querySelectorAll( '.ideas-inbox' ).forEach( bindAddForm );
 	}

--- a/assets/ideas-inbox.js
+++ b/assets/ideas-inbox.js
@@ -1,8 +1,15 @@
 /**
  * Ideas Inbox — client-side progressive enhancement.
  *
- * Replaces the inline `confirm()` fallback on the Delete link with a
- * WPDS ConfirmDialog for a friendlier confirmation experience.
+ * Enhances the server-rendered dashboard widget and submenu page:
+ *  - Intercepts the add form to POST to the REST endpoint and insert
+ *    the returned row HTML without a page reload.
+ *  - Replaces the inline confirm() fallback on delete links with a
+ *    WPDS ConfirmDialog that, on confirm, DELETEs via REST and
+ *    removes the row in place.
+ *
+ * Without JS (or without wp.apiFetch), the form's native POST and
+ * the delete link's own href keep the existing redirect flow.
  */
 
 ( function () {
@@ -19,21 +26,24 @@
 	var useEffect     = wp.element.useEffect;
 	var useCallback   = wp.element.useCallback;
 	var __            = wp.i18n.__;
+	var _n            = wp.i18n._n;
+	var apiFetch      = wp.apiFetch;
 
 	if ( ! ConfirmDialog || ! createRoot ) {
 		return;
 	}
 
 	var DIALOG_EVENT = 'ideas-inbox:confirm-delete';
+	var REST_BASE    = '/ideas-inbox/v1/ideas';
 
 	function DeleteConfirm() {
-		var state    = useState( null );
-		var pending  = state[ 0 ];
+		var state      = useState( null );
+		var pending    = state[ 0 ];
 		var setPending = state[ 1 ];
 
 		useEffect( function () {
 			function onRequest( event ) {
-				setPending( event.detail.url );
+				setPending( event.detail );
 			}
 			document.addEventListener( DIALOG_EVENT, onRequest );
 			return function () {
@@ -52,10 +62,15 @@
 				confirmButtonText: __( 'Delete', 'ideas-dashboard-widget' ),
 				cancelButtonText: __( 'Never mind', 'ideas-dashboard-widget' ),
 				onConfirm: function () {
-					var url = pending;
+					var current = pending;
 					setPending( null );
-					if ( url ) {
-						window.location.href = url;
+					if ( ! current ) {
+						return;
+					}
+					if ( current.id && apiFetch ) {
+						deleteIdea( current );
+					} else if ( current.url ) {
+						window.location.href = current.url;
 					}
 				},
 				onCancel: close,
@@ -64,13 +79,273 @@
 		);
 	}
 
+	function isWidgetContainer( container ) {
+		return !! container.closest( '#ideas_inbox_widget' );
+	}
+
+	function formatCount( total ) {
+		// %s is replaced with the raw number; %d is not used here because
+		// we don't have a locale number formatter in wp.i18n for JS.
+		return _n( '%s idea', '%s ideas', total, 'ideas-dashboard-widget' ).replace( '%s', String( total ) );
+	}
+
+	function escapeHtml( str ) {
+		return String( str )
+			.replace( /&/g, '&amp;' )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' )
+			.replace( /"/g, '&quot;' )
+			.replace( /'/g, '&#39;' );
+	}
+
+	function buildEmptyState( container ) {
+		var hint = isWidgetContainer( container )
+			? __( 'Drop one above to save it for later.', 'ideas-dashboard-widget' )
+			: __( 'Head to your dashboard to add one.', 'ideas-dashboard-widget' );
+		return (
+			'<div class="ideas-inbox__empty">'
+			+ '<span class="dashicons dashicons-lightbulb" aria-hidden="true"></span>'
+			+ '<p class="ideas-inbox__empty-title">' + escapeHtml( __( 'No ideas yet', 'ideas-dashboard-widget' ) ) + '</p>'
+			+ '<p class="ideas-inbox__empty-hint">' + escapeHtml( hint ) + '</p>'
+			+ '</div>'
+		);
+	}
+
+	function buildHeaderAndList( total ) {
+		return (
+			'<div class="ideas-inbox__header">'
+			+ '<span class="ideas-inbox__count">' + escapeHtml( formatCount( total ) ) + '</span>'
+			+ '</div>'
+			+ '<ul class="ideas-inbox__list"></ul>'
+		);
+	}
+
+	function updateCount( container, total ) {
+		var countEl = container.querySelector( '.ideas-inbox__count' );
+		if ( countEl ) {
+			countEl.textContent = formatCount( total );
+		}
+	}
+
+	function updateViewAllLink( container, total ) {
+		// Only the widget shows the "View all" link.
+		if ( ! isWidgetContainer( container ) ) {
+			return;
+		}
+
+		var wrap = container.querySelector( '.ideas-inbox__view-all' );
+
+		if ( total <= 5 ) {
+			if ( wrap ) {
+				wrap.style.display = 'none';
+			}
+			return;
+		}
+
+		var text = __( 'View all ideas (%d) →', 'ideas-dashboard-widget' ).replace( '%d', String( total ) );
+
+		if ( wrap ) {
+			var link = wrap.querySelector( 'a' );
+			if ( link ) {
+				link.textContent = text;
+			}
+			wrap.style.display = '';
+			return;
+		}
+
+		// Create the wrapper when crossing the 5 → 6 threshold.
+		var url = ( window.IdeasInbox && window.IdeasInbox.viewAllUrl ) || '';
+		if ( ! url ) {
+			return;
+		}
+		var p = document.createElement( 'p' );
+		p.className = 'ideas-inbox__view-all';
+		var a = document.createElement( 'a' );
+		a.href = url;
+		a.textContent = text;
+		p.appendChild( a );
+
+		var list = container.querySelector( '.ideas-inbox__list' );
+		if ( list && list.parentNode ) {
+			list.parentNode.insertBefore( p, list.nextSibling );
+		} else {
+			container.appendChild( p );
+		}
+	}
+
+	function getOrCreateNotice( container ) {
+		var existing = container.querySelector( '.ideas-inbox__notice' );
+		if ( existing ) {
+			return existing;
+		}
+		var notice = document.createElement( 'div' );
+		notice.className = 'ideas-inbox__notice notice notice-error inline';
+		notice.setAttribute( 'role', 'alert' );
+		var form = container.querySelector( '.ideas-inbox__form' );
+		if ( form && form.parentNode ) {
+			form.parentNode.insertBefore( notice, form.nextSibling );
+		} else {
+			container.insertBefore( notice, container.firstChild );
+		}
+		return notice;
+	}
+
+	function showError( container, message ) {
+		var notice = getOrCreateNotice( container );
+		notice.innerHTML = '<p>' + escapeHtml( message ) + '</p>';
+	}
+
+	function clearError( container ) {
+		var notice = container.querySelector( '.ideas-inbox__notice' );
+		if ( notice ) {
+			notice.remove();
+		}
+	}
+
+	function extractErrorMessage( err ) {
+		if ( err && err.message ) {
+			return err.message;
+		}
+		return __( 'Something went wrong. Please try again.', 'ideas-dashboard-widget' );
+	}
+
+	function onAddSuccess( container, res ) {
+		clearError( container );
+
+		var empty = container.querySelector( '.ideas-inbox__empty' );
+		if ( empty ) {
+			empty.outerHTML = buildHeaderAndList( res.total );
+		}
+
+		var list = container.querySelector( '.ideas-inbox__list' );
+		if ( list ) {
+			list.insertAdjacentHTML( 'afterbegin', res.html );
+
+			if ( isWidgetContainer( container ) ) {
+				while ( list.children.length > 5 ) {
+					list.removeChild( list.lastElementChild );
+				}
+			}
+		}
+
+		updateCount( container, res.total );
+		updateViewAllLink( container, res.total );
+
+		var textarea = container.querySelector( '.ideas-inbox__textarea' );
+		if ( textarea ) {
+			textarea.value = '';
+			textarea.focus();
+		}
+	}
+
+	function deleteIdea( pending ) {
+		var container = pending.row && pending.row.closest( '.ideas-inbox' );
+		if ( ! container ) {
+			window.location.href = pending.url;
+			return;
+		}
+
+		apiFetch( {
+			path: REST_BASE + '/' + encodeURIComponent( pending.id ),
+			method: 'DELETE',
+		} ).then( function ( res ) {
+			onDeleteSuccess( container, pending.row, res );
+		} ).catch( function ( err ) {
+			showError( container, extractErrorMessage( err ) );
+		} );
+	}
+
+	function onDeleteSuccess( container, row, res ) {
+		clearError( container );
+
+		if ( row && row.parentNode ) {
+			row.remove();
+		}
+
+		if ( res.total === 0 ) {
+			var header  = container.querySelector( '.ideas-inbox__header' );
+			var list    = container.querySelector( '.ideas-inbox__list' );
+			var viewAll = container.querySelector( '.ideas-inbox__view-all' );
+			if ( header ) header.remove();
+			if ( list ) list.remove();
+			if ( viewAll ) viewAll.remove();
+
+			var form = container.querySelector( '.ideas-inbox__form' );
+			var html = buildEmptyState( container );
+			if ( form ) {
+				form.insertAdjacentHTML( 'afterend', html );
+			} else {
+				container.insertAdjacentHTML( 'beforeend', html );
+			}
+			return;
+		}
+
+		// Widget: if the list now has fewer than 5 visible rows but more
+		// ideas exist off-screen, backfill with the server-rendered row.
+		if ( isWidgetContainer( container ) && res.fill_html ) {
+			var widgetList = container.querySelector( '.ideas-inbox__list' );
+			if ( widgetList && widgetList.children.length < 5 ) {
+				widgetList.insertAdjacentHTML( 'beforeend', res.fill_html );
+			}
+		}
+
+		updateCount( container, res.total );
+		updateViewAllLink( container, res.total );
+
+		// Submenu page: if current page is now empty and isn't page 1,
+		// reload to land on a populated page.
+		if ( ! isWidgetContainer( container ) ) {
+			var list2 = container.querySelector( '.ideas-inbox__list' );
+			if ( list2 && list2.children.length === 0 ) {
+				var params = new URLSearchParams( window.location.search );
+				var paged  = parseInt( params.get( 'paged' ) || '1', 10 );
+				if ( paged > 1 ) {
+					window.location.reload();
+				}
+			}
+		}
+	}
+
+	function bindAddForm( container ) {
+		if ( ! apiFetch ) {
+			return;
+		}
+		var form = container.querySelector( '.ideas-inbox__form' );
+		if ( ! form ) {
+			return;
+		}
+		form.addEventListener( 'submit', function ( event ) {
+			var textarea = form.querySelector( '.ideas-inbox__textarea' );
+			var text     = textarea ? textarea.value.trim() : '';
+			if ( ! text ) {
+				return;
+			}
+			event.preventDefault();
+
+			var submit = form.querySelector( 'button[type="submit"]' );
+			if ( submit ) submit.disabled = true;
+
+			apiFetch( {
+				path: REST_BASE,
+				method: 'POST',
+				data: { text: text },
+			} ).then( function ( res ) {
+				onAddSuccess( container, res );
+			} ).catch( function ( err ) {
+				showError( container, extractErrorMessage( err ) );
+			} ).finally( function () {
+				if ( submit ) submit.disabled = false;
+			} );
+		} );
+	}
+
 	function init() {
 		// Mount the dialog portal outside the dashboard widget so it
 		// isn't clipped by postbox overflow rules.
-		var container = document.createElement( 'div' );
-		container.className = 'ideas-inbox-dialog-root';
-		document.body.appendChild( container );
-		createRoot( container ).render( createElement( DeleteConfirm ) );
+		var dialogRoot = document.createElement( 'div' );
+		dialogRoot.className = 'ideas-inbox-dialog-root';
+		document.body.appendChild( dialogRoot );
+		createRoot( dialogRoot ).render( createElement( DeleteConfirm ) );
 
 		// Strip the native confirm() fallback now that the component
 		// dialog is ready. Links without JS keep the inline handler.
@@ -78,20 +353,23 @@
 			link.removeAttribute( 'onclick' );
 		} );
 
-		// Delegate click handling so it also covers any links added
-		// to the DOM later in this page load.
+		// Delegate delete click handling (also covers rows inserted later).
 		document.addEventListener( 'click', function ( event ) {
 			var link = event.target.closest( '.ideas-inbox__delete' );
 			if ( ! link ) {
 				return;
 			}
 			event.preventDefault();
+			var row = link.closest( '.ideas-inbox__row' );
+			var id  = row ? row.getAttribute( 'data-id' ) : '';
 			document.dispatchEvent(
 				new CustomEvent( DIALOG_EVENT, {
-					detail: { url: link.href },
+					detail: { url: link.href, id: id, row: row },
 				} )
 			);
 		} );
+
+		document.querySelectorAll( '.ideas-inbox' ).forEach( bindAddForm );
 	}
 
 	if ( document.readyState === 'loading' ) {

--- a/docs/plans/2026-04-23-ideas-inbox-no-refresh-design.md
+++ b/docs/plans/2026-04-23-ideas-inbox-no-refresh-design.md
@@ -14,7 +14,7 @@ Edit-in-place is planned as a follow-up; the design below introduces stable idea
 - **Endpoint style:** WP REST API, namespace `ideas-inbox/v1`.
 - **Identity:** each idea gets a stable UUID. Positional indexes stay as the no-JS fallback URL shape for existing `admin-post` handlers.
 - **DOM strategy:** PHP is the single source of truth for row markup. The add response returns a pre-rendered `<li>` fragment; JS does `insertAdjacentHTML`. JS duplicates only the empty state and list skeleton (a few lines each).
-- **Widget "fill-in" on delete:** accept a temporary 4-of-N display until next dashboard load. No server-side fill-in logic.
+- **Widget "fill-in" on delete:** *revised during implementation.* The delete response returns a pre-rendered `fill_html` for the next-oldest idea whenever `total >= 5` after the delete. The client appends it when the widget list has fewer than 5 visible rows, keeping the widget consistently full. The earlier "accept a temporary gap" decision was reversed once the gap turned out to be more visible than expected.
 - **Error surface:** inline `notice notice-error` div. No toast / snackbar.
 
 ## Data model
@@ -56,7 +56,8 @@ Namespace: `ideas-inbox/v1`. Auth: `current_user_can( 'edit_posts' )`. Nonce: `w
 ### `DELETE /ideas/{id}`
 
 - Looks up by UUID. Not found → 404.
-- Unsets, saves, returns `{total}`.
+- Unsets, saves, returns `{total, fill_html}`.
+- `fill_html` is the pre-rendered `<li>` for the idea at position `total - 5` in the oldest-first array when `total >= 5`, otherwise `null`. The widget uses it to backfill; the submenu page ignores it.
 
 ## Client JS flow
 

--- a/docs/plans/2026-04-23-ideas-inbox-no-refresh-design.md
+++ b/docs/plans/2026-04-23-ideas-inbox-no-refresh-design.md
@@ -1,0 +1,144 @@
+# Ideas Inbox — no-refresh add/delete
+
+**Issue:** [#10 — Explore disabling hard refresh every time an action is taken on an idea](https://github.com/kellychoffman/ideas-dashboard-widget/issues/10)
+
+## Summary
+
+Today, adding or deleting an idea posts to `admin-post.php` and redirects back, triggering a full page reload. This design replaces those reloads with REST calls that update the DOM in place, while keeping the current form-POST handlers as the no-JS fallback.
+
+Edit-in-place is planned as a follow-up; the design below introduces stable idea IDs so that work drops in cleanly.
+
+## Key decisions
+
+- **Scope:** add + delete only. "Turn into draft" keeps its redirect (it's an intentional navigation to the editor).
+- **Endpoint style:** WP REST API, namespace `ideas-inbox/v1`.
+- **Identity:** each idea gets a stable UUID. Positional indexes stay as the no-JS fallback URL shape for existing `admin-post` handlers.
+- **DOM strategy:** PHP is the single source of truth for row markup. The add response returns a pre-rendered `<li>` fragment; JS does `insertAdjacentHTML`. JS duplicates only the empty state and list skeleton (a few lines each).
+- **Widget "fill-in" on delete:** accept a temporary 4-of-N display until next dashboard load. No server-side fill-in logic.
+- **Error surface:** inline `notice notice-error` div. No toast / snackbar.
+
+## Data model
+
+```php
+array(
+    'id'   => 'a1b2c3d4-...', // NEW — wp_generate_uuid4()
+    'text' => '...',
+    'time' => 1745432100,
+)
+```
+
+**Lazy migration** inside `ideas_inbox_get_ideas()`: any idea without an `id` gets one assigned on first read, persisted on the same request. Idempotent, zero-downtime.
+
+**Helper:**
+
+```php
+function ideas_inbox_find_index_by_id( array $ideas, $id ) {
+    foreach ( $ideas as $k => $idea ) {
+        if ( isset( $idea['id'] ) && hash_equals( $idea['id'], (string) $id ) ) {
+            return $k;
+        }
+    }
+    return false;
+}
+```
+
+## REST endpoints
+
+Namespace: `ideas-inbox/v1`. Auth: `current_user_can( 'edit_posts' )`. Nonce: `wp_rest` via `wp.apiFetch`.
+
+### `POST /ideas`
+
+- Args: `text` (required, string, `sanitize_textarea_field`).
+- Empty text → 400 `empty_idea`.
+- Creates `{id, text, time}`, saves, returns `{id, html, total}`.
+- `html` is `ideas_inbox_render_row($idea)` captured with `ob_start`.
+
+### `DELETE /ideas/{id}`
+
+- Looks up by UUID. Not found → 404.
+- Unsets, saves, returns `{total}`.
+
+## Client JS flow
+
+Dependencies: add `wp-api-fetch` to the script enqueue.
+
+```js
+var apiFetch = wp.apiFetch;
+
+// Intercept add form
+form.addEventListener('submit', async function (e) {
+    if (!apiFetch) return; // no JS support → native POST
+    e.preventDefault();
+    var text = textarea.value.trim();
+    if (!text) return;
+    submitButton.disabled = true;
+    try {
+        var res = await apiFetch({
+            path: '/ideas-inbox/v1/ideas',
+            method: 'POST',
+            data: { text: text },
+        });
+        onAddSuccess(res);
+    } catch (err) {
+        showError(err);
+    } finally {
+        submitButton.disabled = false;
+    }
+});
+```
+
+The existing ConfirmDialog's `onConfirm` changes: instead of `window.location.href = url`, extract the `data-id` from the pending row and call `apiFetch({ method: 'DELETE', path: '/ideas-inbox/v1/ideas/' + id })`.
+
+**DOM sync helpers:**
+
+- `onAddSuccess({id, html, total})`:
+  - If empty state is visible, remove it and inject the list skeleton (header + count span + `<ul>`).
+  - `list.insertAdjacentHTML('afterbegin', html)`.
+  - Widget only: if the list now has more than 5 rows, remove the last.
+  - Update `.ideas-inbox__count`.
+  - Clear textarea, refocus.
+- `onDeleteSuccess({total}, rowElement)`:
+  - Remove the `<li>` by `data-id`.
+  - Update count, "View all (N)" text / visibility.
+  - If `total === 0`: swap list for empty state markup.
+
+JS-side template helpers (`createEmptyState()`, `createListSkeleton()`) stay small and mirror PHP output for those two fragments only.
+
+## Progressive enhancement
+
+- Form keeps `action="admin-post.php"` + the `ideas_inbox_add` hidden input. `e.preventDefault()` runs only when `wp.apiFetch` is available. No JS → native POST → redirect (today's behavior).
+- Delete `<a>` keeps its `admin-post.php` href and inline `confirm()` fallback. JS strips the `onclick` and routes through the ConfirmDialog as it already does. No JS → the native link works.
+- The existing `admin-post` handlers also need to assign a UUID on create so no-JS-created ideas get IDs immediately (not only on next read).
+
+## Edge cases
+
+- **Submenu page, delete leaves page empty, `paged > 1`:** fall back to `window.location.reload()` — simplest, rarely hit.
+- **Two tabs, delete race:** REST returns 404 on stale ID. Inline error; UI stays intact.
+- **Permission change mid-session:** REST returns 401/403; inline error.
+
+## File-by-file changes
+
+1. `ideas-dashboard-widget.php`
+   - Bump `IDEAS_INBOX_VERSION` to `0.4.0`.
+   - `ideas_inbox_get_ideas()` — lazy UUID assignment.
+   - `ideas_inbox_find_index_by_id()` — new.
+   - `ideas_inbox_handle_add()` — assign UUID on create.
+   - `ideas_inbox_render_list()` — extract row into `ideas_inbox_render_row( $idea )`, add `data-id` to `<li>`.
+   - `ideas_inbox_register_rest_routes()` + `ideas_inbox_rest_add()` + `ideas_inbox_rest_delete()` — new.
+   - `ideas_inbox_enqueue_assets()` — add `wp-api-fetch` dep, `wp_add_inline_script` for the namespace constant.
+2. `assets/ideas-inbox.js`
+   - Add submit interceptor, DOM sync helpers, DELETE call from ConfirmDialog.
+3. `assets/ideas-inbox.css`
+   - Minimal additions for the inline error notice (only if `wp-components` doesn't cover it).
+4. `readme.md`
+   - Changelog entry for 0.4.0.
+
+## Testing plan (manual)
+
+1. Fresh install, dashboard widget: add 3 ideas — no refresh, count increments.
+2. With 8 ideas total, delete a visible one from the widget — row removed, count decrements, widget shows 4 (accepted).
+3. Disable JS in DevTools: form submits via POST + redirect; delete link uses inline `confirm()` and redirects.
+4. Submenu page, 21 ideas: delete the only idea on page 2 → page reloads (fallback).
+5. Log out in another tab, attempt delete → inline error, UI intact.
+6. Two tabs, add in A then delete in B with stale state → 404, inline error, UI intact.
+7. Empty state ↔ populated state transitions (first add, last delete) work without reload.

--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Ideas Inbox
  * Description: An ideas inbox for your WP dashboard. Drop ideas for your future self to blog about.
- * Version:     0.3.0
+ * Version:     0.4.0
  * Author:      Kelly Hoffman
  * License:     GPL-2.0-or-later
  * Text Domain: ideas-dashboard-widget
@@ -250,7 +250,7 @@ function ideas_inbox_render_list( array $ideas ) {
 	<?php
 }
 
-function ideas_inbox_render_row( array $idea, $index = 0 ) {
+function ideas_inbox_render_row( array $idea, $index = 0, $include_confirm_fallback = true ) {
 	$id = isset( $idea['id'] ) ? $idea['id'] : '';
 	?>
 	<li class="ideas-inbox__row" data-id="<?php echo esc_attr( $id ); ?>">
@@ -273,7 +273,9 @@ function ideas_inbox_render_row( array $idea, $index = 0 ) {
 					class="ideas-inbox__delete"
 					href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_delete', $index ) ); ?>"
 					aria-label="<?php esc_attr_e( 'Delete idea', 'ideas-dashboard-widget' ); ?>"
+					<?php if ( $include_confirm_fallback ) : ?>
 					onclick="return confirm( <?php echo wp_json_encode( __( 'Delete this idea?', 'ideas-dashboard-widget' ) ); ?> );"
+					<?php endif; ?>
 				>
 					<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 				</a>
@@ -352,7 +354,7 @@ function ideas_inbox_register_rest_routes() {
 
 	register_rest_route(
 		'ideas-inbox/v1',
-		'/ideas/(?P<id>[a-f0-9\-]+)',
+		'/ideas/(?P<id>[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})',
 		array(
 			'methods'             => WP_REST_Server::DELETABLE,
 			'callback'            => 'ideas_inbox_rest_delete',
@@ -362,7 +364,8 @@ function ideas_inbox_register_rest_routes() {
 }
 
 function ideas_inbox_rest_add( WP_REST_Request $request ) {
-	$text = trim( (string) $request['text'] );
+	// $request['text'] is already sanitized + trimmed by sanitize_textarea_field.
+	$text = (string) $request['text'];
 	if ( '' === $text ) {
 		return new WP_Error(
 			'ideas_inbox_empty',
@@ -380,11 +383,12 @@ function ideas_inbox_rest_add( WP_REST_Request $request ) {
 	$ideas[] = $idea;
 	ideas_inbox_save_ideas( $ideas );
 
-	// The newly appended idea sits at the last index of the saved array.
+	// $index is passed to render_row so the rendered row's no-JS
+	// delete/draft hrefs point at the correct positional admin-post URLs.
 	$index = count( $ideas ) - 1;
 
 	ob_start();
-	ideas_inbox_render_row( $idea, $index );
+	ideas_inbox_render_row( $idea, $index, false );
 	$html = ob_get_clean();
 
 	return rest_ensure_response(
@@ -422,7 +426,7 @@ function ideas_inbox_rest_delete( WP_REST_Request $request ) {
 		$fill_index = $total - 5;
 		$fill_idea  = $ideas[ $fill_index ];
 		ob_start();
-		ideas_inbox_render_row( $fill_idea, $fill_index );
+		ideas_inbox_render_row( $fill_idea, $fill_index, false );
 		$fill_html = ob_get_clean();
 	}
 

--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const IDEAS_INBOX_VERSION   = '0.3.0';
+const IDEAS_INBOX_VERSION   = '0.4.0';
 const IDEAS_INBOX_META_KEY  = 'ideas_inbox';
 const IDEAS_INBOX_NONCE     = 'ideas_inbox';
 const IDEAS_INBOX_PAGE_SLUG = 'ideas-inbox';
@@ -23,6 +23,7 @@ add_action( 'admin_enqueue_scripts', 'ideas_inbox_enqueue_assets' );
 add_action( 'admin_post_ideas_inbox_add',    'ideas_inbox_handle_add' );
 add_action( 'admin_post_ideas_inbox_delete', 'ideas_inbox_handle_delete' );
 add_action( 'admin_post_ideas_inbox_draft',  'ideas_inbox_handle_draft' );
+add_action( 'rest_api_init',                 'ideas_inbox_register_rest_routes' );
 
 function ideas_inbox_enqueue_assets( $hook ) {
 	$ideas_inbox_page_hook = 'posts_page_' . IDEAS_INBOX_PAGE_SLUG;
@@ -43,9 +44,18 @@ function ideas_inbox_enqueue_assets( $hook ) {
 	wp_enqueue_script(
 		'ideas-inbox',
 		plugins_url( 'assets/ideas-inbox.js', __FILE__ ),
-		array( 'wp-components', 'wp-element', 'wp-i18n' ),
+		array( 'wp-api-fetch', 'wp-components', 'wp-element', 'wp-i18n' ),
 		IDEAS_INBOX_VERSION,
 		true
+	);
+	wp_add_inline_script(
+		'ideas-inbox',
+		'window.IdeasInbox = ' . wp_json_encode(
+			array(
+				'viewAllUrl' => add_query_arg( 'page', IDEAS_INBOX_PAGE_SLUG, admin_url( 'edit.php' ) ),
+			)
+		) . ';',
+		'before'
 	);
 	wp_set_script_translations( 'ideas-inbox', 'ideas-dashboard-widget' );
 }
@@ -74,11 +84,34 @@ function ideas_inbox_register_page() {
 
 function ideas_inbox_get_ideas() {
 	$ideas = get_user_meta( get_current_user_id(), IDEAS_INBOX_META_KEY, true );
-	return is_array( $ideas ) ? $ideas : array();
+	if ( ! is_array( $ideas ) ) {
+		return array();
+	}
+
+	$dirty = false;
+	foreach ( $ideas as $k => $idea ) {
+		if ( empty( $idea['id'] ) ) {
+			$ideas[ $k ]['id'] = wp_generate_uuid4();
+			$dirty = true;
+		}
+	}
+	if ( $dirty ) {
+		ideas_inbox_save_ideas( $ideas );
+	}
+	return $ideas;
 }
 
 function ideas_inbox_save_ideas( array $ideas ) {
 	update_user_meta( get_current_user_id(), IDEAS_INBOX_META_KEY, array_values( $ideas ) );
+}
+
+function ideas_inbox_find_index_by_id( array $ideas, $id ) {
+	foreach ( $ideas as $k => $idea ) {
+		if ( isset( $idea['id'] ) && hash_equals( $idea['id'], (string) $id ) ) {
+			return $k;
+		}
+	}
+	return false;
 }
 
 function ideas_inbox_render_widget() {
@@ -211,35 +244,42 @@ function ideas_inbox_render_list( array $ideas ) {
 	?>
 	<ul class="ideas-inbox__list">
 		<?php foreach ( $ideas as $index => $idea ) : ?>
-			<li class="ideas-inbox__row">
-				<div class="ideas-inbox__row-text"><?php echo esc_html( $idea['text'] ); ?></div>
-				<div class="ideas-inbox__row-meta">
-					<span class="ideas-inbox__row-time">
-						<?php
-						/* translators: %s: human-readable time difference, e.g. "3 hours" */
-						echo esc_html( sprintf( __( '%s ago', 'ideas-dashboard-widget' ), human_time_diff( (int) $idea['time'] ) ) );
-						?>
-					</span>
-					<span class="ideas-inbox__row-actions">
-						<a
-							class="button button-small"
-							href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_draft', $index ) ); ?>"
-						>
-							<?php esc_html_e( 'Turn into draft', 'ideas-dashboard-widget' ); ?>
-						</a>
-						<a
-							class="ideas-inbox__delete"
-							href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_delete', $index ) ); ?>"
-							aria-label="<?php esc_attr_e( 'Delete idea', 'ideas-dashboard-widget' ); ?>"
-							onclick="return confirm( <?php echo wp_json_encode( __( 'Delete this idea?', 'ideas-dashboard-widget' ) ); ?> );"
-						>
-							<span class="dashicons dashicons-trash" aria-hidden="true"></span>
-						</a>
-					</span>
-				</div>
-			</li>
+			<?php ideas_inbox_render_row( $idea, $index ); ?>
 		<?php endforeach; ?>
 	</ul>
+	<?php
+}
+
+function ideas_inbox_render_row( array $idea, $index = 0 ) {
+	$id = isset( $idea['id'] ) ? $idea['id'] : '';
+	?>
+	<li class="ideas-inbox__row" data-id="<?php echo esc_attr( $id ); ?>">
+		<div class="ideas-inbox__row-text"><?php echo esc_html( $idea['text'] ); ?></div>
+		<div class="ideas-inbox__row-meta">
+			<span class="ideas-inbox__row-time">
+				<?php
+				/* translators: %s: human-readable time difference, e.g. "3 hours" */
+				echo esc_html( sprintf( __( '%s ago', 'ideas-dashboard-widget' ), human_time_diff( (int) $idea['time'] ) ) );
+				?>
+			</span>
+			<span class="ideas-inbox__row-actions">
+				<a
+					class="button button-small"
+					href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_draft', $index ) ); ?>"
+				>
+					<?php esc_html_e( 'Turn into draft', 'ideas-dashboard-widget' ); ?>
+				</a>
+				<a
+					class="ideas-inbox__delete"
+					href="<?php echo esc_url( ideas_inbox_action_url( 'ideas_inbox_delete', $index ) ); ?>"
+					aria-label="<?php esc_attr_e( 'Delete idea', 'ideas-dashboard-widget' ); ?>"
+					onclick="return confirm( <?php echo wp_json_encode( __( 'Delete this idea?', 'ideas-dashboard-widget' ) ); ?> );"
+				>
+					<span class="dashicons dashicons-trash" aria-hidden="true"></span>
+				</a>
+			</span>
+		</div>
+	</li>
 	<?php
 }
 
@@ -278,6 +318,7 @@ function ideas_inbox_handle_add() {
 	if ( '' !== trim( $text ) ) {
 		$ideas   = ideas_inbox_get_ideas();
 		$ideas[] = array(
+			'id'   => wp_generate_uuid4(),
 			'text' => $text,
 			'time' => time(),
 		);
@@ -285,6 +326,112 @@ function ideas_inbox_handle_add() {
 	}
 
 	ideas_inbox_redirect_back();
+}
+
+function ideas_inbox_register_rest_routes() {
+	$permission = static function () {
+		return current_user_can( 'edit_posts' );
+	};
+
+	register_rest_route(
+		'ideas-inbox/v1',
+		'/ideas',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'ideas_inbox_rest_add',
+			'permission_callback' => $permission,
+			'args'                => array(
+				'text' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_textarea_field',
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		'ideas-inbox/v1',
+		'/ideas/(?P<id>[a-f0-9\-]+)',
+		array(
+			'methods'             => WP_REST_Server::DELETABLE,
+			'callback'            => 'ideas_inbox_rest_delete',
+			'permission_callback' => $permission,
+		)
+	);
+}
+
+function ideas_inbox_rest_add( WP_REST_Request $request ) {
+	$text = trim( (string) $request['text'] );
+	if ( '' === $text ) {
+		return new WP_Error(
+			'ideas_inbox_empty',
+			__( 'Idea cannot be empty.', 'ideas-dashboard-widget' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$ideas = ideas_inbox_get_ideas();
+	$idea  = array(
+		'id'   => wp_generate_uuid4(),
+		'text' => $text,
+		'time' => time(),
+	);
+	$ideas[] = $idea;
+	ideas_inbox_save_ideas( $ideas );
+
+	// The newly appended idea sits at the last index of the saved array.
+	$index = count( $ideas ) - 1;
+
+	ob_start();
+	ideas_inbox_render_row( $idea, $index );
+	$html = ob_get_clean();
+
+	return rest_ensure_response(
+		array(
+			'id'    => $idea['id'],
+			'html'  => $html,
+			'total' => count( $ideas ),
+		)
+	);
+}
+
+function ideas_inbox_rest_delete( WP_REST_Request $request ) {
+	$ideas = ideas_inbox_get_ideas();
+	$index = ideas_inbox_find_index_by_id( $ideas, $request['id'] );
+
+	if ( false === $index ) {
+		return new WP_Error(
+			'ideas_inbox_not_found',
+			__( 'Idea not found.', 'ideas-dashboard-widget' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	unset( $ideas[ $index ] );
+	$ideas = array_values( $ideas );
+	ideas_inbox_save_ideas( $ideas );
+
+	$total     = count( $ideas );
+	$fill_html = null;
+
+	// Widget shows the 5 most recent. When total is still ≥ 5, the idea
+	// that should now be the bottom visible row sits at index total - 5
+	// of the oldest-first array. Client decides whether to use this.
+	if ( $total >= 5 ) {
+		$fill_index = $total - 5;
+		$fill_idea  = $ideas[ $fill_index ];
+		ob_start();
+		ideas_inbox_render_row( $fill_idea, $fill_index );
+		$fill_html = ob_get_clean();
+	}
+
+	return rest_ensure_response(
+		array(
+			'total'     => $total,
+			'fill_html' => $fill_html,
+		)
+	);
 }
 
 function ideas_inbox_handle_delete() {

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,13 @@ This plugin is deliberately small:
   - **Turn into draft** — creates a draft post with the idea as the content (and a trimmed title), removes it from the inbox, and opens the post editor.
   - **Delete** — removes the idea from the inbox.
 
+## Changelog
+
+### 0.4.0
+
+- Add and delete ideas without a full page reload. Uses a `ideas-inbox/v1` REST namespace with `wp.apiFetch`; the existing `admin-post.php` handlers stay as the no-JS fallback.
+- Each idea now carries a stable UUID. Existing ideas get IDs assigned lazily on first read.
+
 ## License
 
 GPL-2.0-or-later


### PR DESCRIPTION
Closes #10.

## Summary

- New `ideas-inbox/v1` REST namespace with `POST /ideas` and `DELETE /ideas/{uuid}`; both guarded by `current_user_can( 'edit_posts' )`.
- Each idea now carries a stable UUID (lazy-migrated on first read for existing users, assigned on create everywhere).
- Client uses `wp.apiFetch` to add/delete in place, updating the row list, count badge, "View all (N)" link, and empty state without a reload.
- Delete response includes a pre-rendered fill-in `<li>` so the dashboard widget stays at 5 visible rows.
- Existing `admin-post.php` handlers are unchanged and continue to serve as the no-JS fallback — form POST and delete links still work if JS is disabled.

Design doc: [`docs/plans/2026-04-23-ideas-inbox-no-refresh-design.md`](docs/plans/2026-04-23-ideas-inbox-no-refresh-design.md).

## Test plan

- [ ] Dashboard widget: add an idea — new row appears, count increments, no reload.
- [ ] Dashboard widget: delete a visible row with 6+ total ideas — row is removed, next-oldest slides in, count stays accurate.
- [ ] Dashboard widget: delete the last idea — empty state re-appears without a reload.
- [ ] Dashboard widget: adding a 6th idea surfaces the "View all ideas (6) →" link; deleting back to 5 hides it.
- [ ] Posts → Ideas Inbox submenu page: add/delete works without reload; deleting the only idea on a non-first page reloads to a populated page.
- [ ] Disable JS in DevTools — add form still POSTs via `admin-post.php`; delete link still uses the inline `confirm()` fallback and redirects. No regressions.
- [ ] Open two tabs; delete the same idea from one, try from the other — second attempt shows an inline error notice, UI stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)