### PR TITLE
Update dashboard widget design

### DIFF
--- a/assets/ideas-inbox.css
+++ b/assets/ideas-inbox.css
@@ -11,40 +11,55 @@
 	color: var( --wpds-color-fg-content-neutral, #1e1e1e );
 }
 
-/* Form surface */
+/* Writing surface — gray header band that extends edge-to-edge of the
+   postbox, separated from the white list section below by a hairline,
+   matching the standard core dashboard widget pattern. The -12px left
+   and right margins counteract the .postbox .inside padding (12px). */
+
+/* Drop the .postbox .inside top spacing so the gray header band sits
+   flush with the postbox header — only inside our widget. */
+#ideas_inbox_widget .inside {
+	margin-top: 0;
+	padding-top: 0;
+}
 
 .ideas-inbox__form {
 	background: var( --wpds-color-bg-surface-neutral-weak, #f6f7f7 );
-	border: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
-	border-radius: var( --wpds-border-radius-md, 4px );
+	border: none;
+	border-bottom: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
+	border-radius: 0;
 	padding: var( --wpds-dimension-padding-md, 12px );
-	margin: 0 0 var( --wpds-dimension-gap-md, 16px );
+	margin: 0 -12px var( --wpds-dimension-gap-md, 16px );
 }
 
 .ideas-inbox__textarea {
 	width: 100%;
 	box-sizing: border-box;
 	margin: 0;
-	padding: var( --wpds-dimension-padding-sm, 8px );
+	padding: var( --wpds-dimension-padding-md, 12px );
 	font: inherit;
+	font-size: var( --wpds-typography-font-size-md, 13px );
+	line-height: 1.7;
 	color: inherit;
-	background: var( --wpds-color-bg-surface-neutral, #fff );
-	border: 1px solid var( --wpds-color-stroke-interactive-neutral, #8c8f94 );
-	border-radius: var( --wpds-border-radius-sm, 2px );
-	resize: vertical;
-	min-height: 3.5em;
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	resize: none;
+	min-height: 12em;
+	outline: none;
+	box-shadow: none;
 }
 
 .ideas-inbox__textarea:focus {
 	outline: none;
-	border-color: var( --wpds-color-stroke-focus-brand, var( --wp-admin-theme-color, #3858e9 ) );
-	box-shadow: 0 0 0 var( --wpds-border-width-focus, 2px ) var( --wpds-color-stroke-focus-brand, var( --wp-admin-theme-color, #3858e9 ) );
+	box-shadow: none;
 }
 
 .ideas-inbox__form-actions {
 	display: flex;
 	justify-content: flex-end;
-	margin: var( --wpds-dimension-gap-sm, 8px ) 0 0;
+	margin: var( --wpds-dimension-gap-md, 16px ) 0 0;
+	padding: 0 10px 10px 0;
 }
 
 /* List + rows */
@@ -81,7 +96,6 @@
 	align-items: baseline;
 	gap: var( --wpds-dimension-gap-sm, 8px );
 	padding: var( --wpds-dimension-padding-sm, 8px ) var( --wpds-dimension-padding-xs, 4px );
-	border-top: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
 	border-radius: var( --wpds-border-radius-sm, 2px );
 }
 
@@ -152,8 +166,8 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 28px;
-	height: 28px;
+	width: 26px;
+	height: 26px;
 	padding: 0;
 	background: transparent;
 	border: 1px solid transparent;

--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -130,8 +130,8 @@ function ideas_inbox_render_widget() {
 				id="ideas-inbox-idea"
 				class="ideas-inbox__textarea"
 				name="idea"
-				rows="2"
-				placeholder="<?php esc_attr_e( 'Drop an idea for future you…', 'ideas-dashboard-widget' ); ?>"
+				rows="7"
+				placeholder="<?php esc_attr_e( 'Jot it down…', 'ideas-dashboard-widget' ); ?>"
 				required
 			></textarea>
 			<p class="ideas-inbox__form-actions">


### PR DESCRIPTION
## Summary

Tightens the Ideas Inbox dashboard widget so it feels more like a notepad than a draft-post creator, and matches the visual rhythm of core dashboard widgets (light-gray header band over a white content area).

### Form / writing area
- Form is now a light-gray surface that extends edge-to-edge of the postbox (via -12px horizontal margins), separated from the white list section below by a hairline border. A scoped `#ideas_inbox_widget .inside { padding-top: 0; margin-top: 0 }` override makes the band sit flush with the postbox header — no more white sliver between them.
- The textarea is bigger and chrome-less: transparent background, no border, no resize handle, `min-height: 12em`, `line-height: 1.7`. The `rows` attribute is bumped to 7 for the no-CSS fallback.
- Placeholder copy: _"Jot it down…"_
- `.ideas-inbox__form-actions` gets 10px right/bottom padding so the **Add idea** button visually aligns with the row content below instead of poking past the inset.

### List rows
- The 1px hairline between rows is dropped — cleaner, less ruled-list feel.
- The trash icon's box matches `.button-small` (26×26) so it lines up with the **Turn into draft** button.

## Test plan

- [ ] Open the Playground preview from the sticky PR comment.
- [ ] On `/wp-admin/index.php`, confirm the Ideas Inbox widget renders with a light-gray header band on top (form area) and a white list area below — no white gap between the postbox header and the gray band.
- [ ] The textarea feels like a notepad: no visible border at rest or focus, taller initial size, "Jot it down…" placeholder.
- [ ] Add an idea. Confirm rows have no separator lines between them, the trash icon vertically aligns with the **Turn into draft** button, and the **Add idea** button doesn't sit flush against the form's right/bottom edges.
- [ ] Switch admin color schemes — focus rings and gray/white contrast still read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
