### PR TITLE
Add click-to-edit for ideas in the dashboard widget

### DIFF
--- a/assets/ideas-inbox.css
+++ b/assets/ideas-inbox.css
@@ -58,6 +58,7 @@
 .ideas-inbox__form-actions {
 	display: flex;
 	justify-content: flex-end;
+	gap: var( --wpds-dimension-gap-sm, 8px );
 	margin: var( --wpds-dimension-gap-md, 16px ) 0 0;
 	padding: 0 10px 10px 0;
 }
@@ -106,6 +107,27 @@
 	word-break: break-word;
 	font-size: var( --wpds-typography-font-size-md, 13px );
 	line-height: var( --wpds-typography-line-height-md, 1.5 );
+	/* Reset native button styles since the row text is rendered as a <button>
+	   so it's keyboard-activatable for click-to-edit. */
+	background: transparent;
+	border: 0;
+	padding: 0;
+	margin: 0;
+	color: inherit;
+	font-family: inherit;
+	text-align: left;
+	cursor: pointer;
+	appearance: none;
+}
+
+.ideas-inbox__row-text:hover {
+	color: var( --wpds-color-fg-content-link, #2271b1 );
+}
+
+.ideas-inbox__row-text:focus-visible {
+	outline: 2px solid var( --wpds-color-stroke-focus, #2271b1 );
+	outline-offset: 2px;
+	border-radius: var( --wpds-border-radius-sm, 2px );
 }
 
 .ideas-inbox__row-meta {

--- a/assets/ideas-inbox.js
+++ b/assets/ideas-inbox.js
@@ -28,23 +28,55 @@
 	var _n            = wp.i18n._n;
 	var apiFetch      = wp.apiFetch;
 
-	// The delete dialog depends on Components; the add flow does not.
-	// Guard them independently so the add-form enhancement still
-	// activates even if __experimentalConfirmDialog is renamed or removed.
-	var ConfirmDialog   = wp.components && wp.components.__experimentalConfirmDialog;
-	var hasDeleteDialog = !! ( ConfirmDialog && createRoot );
+	// The shared confirm modal depends on Components; the add/edit flow
+	// degrades gracefully without it. Guard them independently so the
+	// add-form enhancement still activates even if __experimentalConfirmDialog
+	// is renamed or removed.
+	var ConfirmDialog = wp.components && wp.components.__experimentalConfirmDialog;
+	var hasModal      = !! ( ConfirmDialog && createRoot );
 
-	var DIALOG_EVENT = 'ideas-inbox:confirm-delete';
+	function confirmAction( opts ) {
+		if ( hasModal ) {
+			return confirmWith( opts );
+		}
+		return Promise.resolve( window.confirm( opts.message ) );
+	}
+
+	var DIALOG_EVENT = 'ideas-inbox:confirm';
 	var REST_BASE    = '/ideas-inbox/v1/ideas';
 
-	function DeleteConfirm() {
+	// Promise-based wrapper around the ConfirmDialog portal. Lets both the
+	// delete flow and the discard-edit flow use the same modal UI.
+	function confirmWith( opts ) {
+		return new Promise( function ( resolve ) {
+			document.dispatchEvent(
+				new CustomEvent( DIALOG_EVENT, {
+					detail: {
+						message: opts.message,
+						confirmText: opts.confirmText,
+						cancelText: opts.cancelText,
+						resolve: resolve,
+					},
+				} )
+			);
+		} );
+	}
+
+	function ConfirmManager() {
 		var state      = useState( null );
 		var pending    = state[ 0 ];
 		var setPending = state[ 1 ];
 
 		useEffect( function () {
 			function onRequest( event ) {
-				setPending( event.detail );
+				// If a previous prompt is still pending (shouldn't normally
+				// happen), resolve it as cancelled before swapping in the new one.
+				setPending( function ( prev ) {
+					if ( prev && prev.resolve ) {
+						prev.resolve( false );
+					}
+					return event.detail;
+				} );
 			}
 			document.addEventListener( DIALOG_EVENT, onRequest );
 			return function () {
@@ -52,31 +84,25 @@
 			};
 		}, [] );
 
-		var close = useCallback( function () {
-			setPending( null );
+		var settle = useCallback( function ( value ) {
+			setPending( function ( prev ) {
+				if ( prev && prev.resolve ) {
+					prev.resolve( value );
+				}
+				return null;
+			} );
 		}, [] );
 
 		return createElement(
 			ConfirmDialog,
 			{
 				isOpen: pending !== null,
-				confirmButtonText: __( 'Delete', 'ideas-dashboard-widget' ),
-				cancelButtonText: __( 'Never mind', 'ideas-dashboard-widget' ),
-				onConfirm: function () {
-					var current = pending;
-					setPending( null );
-					if ( ! current ) {
-						return;
-					}
-					if ( current.id && apiFetch ) {
-						deleteIdea( current );
-					} else if ( current.url ) {
-						window.location.href = current.url;
-					}
-				},
-				onCancel: close,
+				confirmButtonText: pending ? pending.confirmText : '',
+				cancelButtonText: pending ? pending.cancelText : '',
+				onConfirm: function () { settle( true ); },
+				onCancel: function () { settle( false ); },
 			},
-			__( "Just double checking you want to delete this idea. It can't be undone.", 'ideas-dashboard-widget' )
+			pending ? pending.message : ''
 		);
 	}
 
@@ -413,19 +439,27 @@
 				return;
 			}
 
+			// The button contains only the raw idea text rendered via esc_html;
+			// textContent decodes entities back to the original characters.
+			var nextText = btn.textContent;
+
 			if ( hasUnsavedChanges() ) {
-				var proceed = window.confirm(
-					__( 'Discard your unsaved idea?', 'ideas-dashboard-widget' )
-				);
-				if ( ! proceed ) {
-					return;
-				}
+				confirmAction( {
+					message: __( 'Discard your unsaved idea?', 'ideas-dashboard-widget' ),
+					confirmText: __( 'Discard', 'ideas-dashboard-widget' ),
+					cancelText: __( 'Keep editing', 'ideas-dashboard-widget' ),
+				} ).then( function ( ok ) {
+					if ( ! ok ) {
+						return;
+					}
+					clearError( container );
+					enterEdit( id, nextText );
+				} );
+				return;
 			}
 
 			clearError( container );
-			// The button contains only the raw idea text rendered via esc_html;
-			// textContent decodes entities back to the original characters.
-			enterEdit( id, btn.textContent );
+			enterEdit( id, nextText );
 		} );
 
 		form.addEventListener( 'submit', function ( event ) {
@@ -469,13 +503,13 @@
 	}
 
 	function init() {
-		if ( hasDeleteDialog ) {
+		if ( hasModal ) {
 			// Mount the dialog portal outside the dashboard widget so it
 			// isn't clipped by postbox overflow rules.
 			var dialogRoot = document.createElement( 'div' );
 			dialogRoot.className = 'ideas-inbox-dialog-root';
 			document.body.appendChild( dialogRoot );
-			createRoot( dialogRoot ).render( createElement( DeleteConfirm ) );
+			createRoot( dialogRoot ).render( createElement( ConfirmManager ) );
 
 			// Strip the native confirm() fallback now that the component
 			// dialog is ready. Links without JS keep the inline handler.
@@ -492,11 +526,20 @@
 				event.preventDefault();
 				var row = link.closest( '.ideas-inbox__row' );
 				var id  = row ? row.getAttribute( 'data-id' ) : '';
-				document.dispatchEvent(
-					new CustomEvent( DIALOG_EVENT, {
-						detail: { url: link.href, id: id, row: row },
-					} )
-				);
+				confirmAction( {
+					message: __( "Just double checking you want to delete this idea. It can't be undone.", 'ideas-dashboard-widget' ),
+					confirmText: __( 'Delete', 'ideas-dashboard-widget' ),
+					cancelText: __( 'Never mind', 'ideas-dashboard-widget' ),
+				} ).then( function ( ok ) {
+					if ( ! ok ) {
+						return;
+					}
+					if ( id && apiFetch ) {
+						deleteIdea( { id: id, row: row, url: link.href } );
+					} else if ( link.href ) {
+						window.location.href = link.href;
+					}
+				} );
 			} );
 		}
 

--- a/assets/ideas-inbox.js
+++ b/assets/ideas-inbox.js
@@ -347,7 +347,7 @@
 		cancelBtn.type = 'button';
 		cancelBtn.className = 'button ideas-inbox__cancel';
 		cancelBtn.textContent = __( 'Cancel', 'ideas-dashboard-widget' );
-		cancelBtn.hidden = true;
+		cancelBtn.style.display = 'none';
 		if ( actions ) {
 			actions.appendChild( cancelBtn );
 		}
@@ -366,7 +366,7 @@
 			if ( submit ) {
 				submit.textContent = saveLabel;
 			}
-			cancelBtn.hidden = false;
+			cancelBtn.style.display = '';
 		}
 
 		function exitEdit() {
@@ -377,7 +377,7 @@
 			if ( submit ) {
 				submit.textContent = addLabel;
 			}
-			cancelBtn.hidden = true;
+			cancelBtn.style.display = 'none';
 		}
 
 		function hasUnsavedChanges() {

--- a/assets/ideas-inbox.js
+++ b/assets/ideas-inbox.js
@@ -307,6 +307,25 @@
 		}
 	}
 
+	function onUpdateSuccess( container, id, res ) {
+		clearError( container );
+		if ( ! res || ! res.html ) {
+			return;
+		}
+		var row = container.querySelector(
+			'.ideas-inbox__row[data-id="' + id + '"]'
+		);
+		if ( ! row ) {
+			return;
+		}
+		var template = document.createElement( 'template' );
+		template.innerHTML = res.html.trim();
+		var newRow = template.content.firstElementChild;
+		if ( newRow ) {
+			row.replaceWith( newRow );
+		}
+	}
+
 	function bindAddForm( container ) {
 		if ( ! apiFetch ) {
 			return;
@@ -315,16 +334,125 @@
 		if ( ! form ) {
 			return;
 		}
+
+		var textarea  = form.querySelector( '.ideas-inbox__textarea' );
+		var submit    = form.querySelector( 'button[type="submit"]' );
+		var actions   = form.querySelector( '.ideas-inbox__form-actions' );
+		var addLabel  = submit ? submit.textContent : __( 'Add idea', 'ideas-dashboard-widget' );
+		var saveLabel = __( 'Save', 'ideas-dashboard-widget' );
+
+		// Inject a Cancel button alongside Save/Add. JS-only — no-JS users
+		// don't need a way to cancel because they can't enter edit mode.
+		var cancelBtn = document.createElement( 'button' );
+		cancelBtn.type = 'button';
+		cancelBtn.className = 'button ideas-inbox__cancel';
+		cancelBtn.textContent = __( 'Cancel', 'ideas-dashboard-widget' );
+		cancelBtn.hidden = true;
+		if ( actions ) {
+			actions.appendChild( cancelBtn );
+		}
+
+		var editing = null; // { id, originalText } when editing.
+
+		function enterEdit( id, text ) {
+			editing = { id: id, originalText: text };
+			if ( textarea ) {
+				textarea.value = text;
+				textarea.focus();
+				try {
+					textarea.setSelectionRange( text.length, text.length );
+				} catch ( e ) {}
+			}
+			if ( submit ) {
+				submit.textContent = saveLabel;
+			}
+			cancelBtn.hidden = false;
+		}
+
+		function exitEdit() {
+			editing = null;
+			if ( textarea ) {
+				textarea.value = '';
+			}
+			if ( submit ) {
+				submit.textContent = addLabel;
+			}
+			cancelBtn.hidden = true;
+		}
+
+		function hasUnsavedChanges() {
+			if ( ! textarea ) {
+				return false;
+			}
+			var current = textarea.value;
+			if ( editing ) {
+				return current !== editing.originalText;
+			}
+			return current.trim() !== '';
+		}
+
+		cancelBtn.addEventListener( 'click', function () {
+			clearError( container );
+			exitEdit();
+		} );
+
+		// Click on an idea's text button → load it into the textarea for editing.
+		container.addEventListener( 'click', function ( event ) {
+			var btn = event.target.closest( '.ideas-inbox__row-text' );
+			if ( ! btn || ! container.contains( btn ) ) {
+				return;
+			}
+			var row = btn.closest( '.ideas-inbox__row' );
+			var id  = row ? row.getAttribute( 'data-id' ) : '';
+			if ( ! id ) {
+				return;
+			}
+
+			if ( editing && editing.id === id ) {
+				if ( textarea ) textarea.focus();
+				return;
+			}
+
+			if ( hasUnsavedChanges() ) {
+				var proceed = window.confirm(
+					__( 'Discard your unsaved idea?', 'ideas-dashboard-widget' )
+				);
+				if ( ! proceed ) {
+					return;
+				}
+			}
+
+			clearError( container );
+			// The button contains only the raw idea text rendered via esc_html;
+			// textContent decodes entities back to the original characters.
+			enterEdit( id, btn.textContent );
+		} );
+
 		form.addEventListener( 'submit', function ( event ) {
-			var textarea = form.querySelector( '.ideas-inbox__textarea' );
-			var text     = textarea ? textarea.value.trim() : '';
+			var text = textarea ? textarea.value.trim() : '';
 			if ( ! text ) {
 				return;
 			}
 			event.preventDefault();
 
-			var submit = form.querySelector( 'button[type="submit"]' );
 			if ( submit ) submit.disabled = true;
+
+			if ( editing ) {
+				var editingId = editing.id;
+				apiFetch( {
+					path: REST_BASE + '/' + editingId,
+					method: 'PATCH',
+					data: { text: text },
+				} ).then( function ( res ) {
+					onUpdateSuccess( container, editingId, res );
+					exitEdit();
+				} ).catch( function ( err ) {
+					showError( container, extractErrorMessage( err ) );
+				} ).finally( function () {
+					if ( submit ) submit.disabled = false;
+				} );
+				return;
+			}
 
 			apiFetch( {
 				path: REST_BASE,

--- a/ideas-dashboard-widget.php
+++ b/ideas-dashboard-widget.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Ideas Inbox
  * Description: An ideas inbox for your WP dashboard. Drop ideas for your future self to blog about.
- * Version:     0.4.0
+ * Version:     0.5.0
  * Author:      Kelly Hoffman
  * License:     GPL-2.0-or-later
  * Text Domain: ideas-dashboard-widget
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const IDEAS_INBOX_VERSION   = '0.4.0';
+const IDEAS_INBOX_VERSION   = '0.5.0';
 const IDEAS_INBOX_META_KEY  = 'ideas_inbox';
 const IDEAS_INBOX_NONCE     = 'ideas_inbox';
 const IDEAS_INBOX_PAGE_SLUG = 'ideas-inbox';
@@ -254,7 +254,11 @@ function ideas_inbox_render_row( array $idea, $index = 0, $include_confirm_fallb
 	$id = isset( $idea['id'] ) ? $idea['id'] : '';
 	?>
 	<li class="ideas-inbox__row" data-id="<?php echo esc_attr( $id ); ?>">
-		<div class="ideas-inbox__row-text"><?php echo esc_html( $idea['text'] ); ?></div>
+		<button
+			type="button"
+			class="ideas-inbox__row-text"
+			aria-label="<?php esc_attr_e( 'Edit idea', 'ideas-dashboard-widget' ); ?>"
+		><?php echo esc_html( $idea['text'] ); ?></button>
 		<div class="ideas-inbox__row-meta">
 			<span class="ideas-inbox__row-time">
 				<?php
@@ -356,9 +360,23 @@ function ideas_inbox_register_rest_routes() {
 		'ideas-inbox/v1',
 		'/ideas/(?P<id>[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})',
 		array(
-			'methods'             => WP_REST_Server::DELETABLE,
-			'callback'            => 'ideas_inbox_rest_delete',
-			'permission_callback' => $permission,
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => 'ideas_inbox_rest_delete',
+				'permission_callback' => $permission,
+			),
+			array(
+				'methods'             => 'PATCH',
+				'callback'            => 'ideas_inbox_rest_update',
+				'permission_callback' => $permission,
+				'args'                => array(
+					'text' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_textarea_field',
+					),
+				),
+			),
 		)
 	);
 }
@@ -396,6 +414,42 @@ function ideas_inbox_rest_add( WP_REST_Request $request ) {
 			'id'    => $idea['id'],
 			'html'  => $html,
 			'total' => count( $ideas ),
+		)
+	);
+}
+
+function ideas_inbox_rest_update( WP_REST_Request $request ) {
+	$text = (string) $request['text'];
+	if ( '' === $text ) {
+		return new WP_Error(
+			'ideas_inbox_empty',
+			__( 'Idea cannot be empty.', 'ideas-dashboard-widget' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$ideas = ideas_inbox_get_ideas();
+	$index = ideas_inbox_find_index_by_id( $ideas, $request['id'] );
+
+	if ( false === $index ) {
+		return new WP_Error(
+			'ideas_inbox_not_found',
+			__( 'Idea not found.', 'ideas-dashboard-widget' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	$ideas[ $index ]['text'] = $text;
+	ideas_inbox_save_ideas( $ideas );
+
+	ob_start();
+	ideas_inbox_render_row( $ideas[ $index ], $index, false );
+	$html = ob_get_clean();
+
+	return rest_ensure_response(
+		array(
+			'id'   => $ideas[ $index ]['id'],
+			'html' => $html,
 		)
 	);
 }

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,10 @@ This plugin is deliberately small:
 
 ## Changelog
 
+### 0.5.0
+
+- Click an idea's text in the dashboard widget to load it back into the textarea for editing. The submit button switches to **Save**, and a **Cancel** button returns the form to a fresh entry. Editing preserves the idea's original timestamp. Adds `PATCH /ideas-inbox/v1/ideas/{id}` for the update.
+
 ### 0.4.0
 
 - Add and delete ideas without a full page reload. Uses a `ideas-inbox/v1` REST namespace with `wp.apiFetch`; the existing `admin-post.php` handlers stay as the no-JS fallback.


### PR DESCRIPTION
Closes #14.

## Summary

- Click an idea's text in the dashboard widget to load it back into the textarea for editing.
- Submit button switches to **Save**; a **Cancel** button returns the form to a fresh entry.
- Editing preserves the idea's original timestamp (so it doesn't jump to the top).
- New `PATCH /ideas-inbox/v1/ideas/{id}` REST route handles the update.
- If the textarea has unsaved content (new draft, or edits to a different idea), clicking another idea prompts: *"Discard your unsaved idea?"* before switching.

## Scope (v1)

- **Widget only.** The All Ideas submenu page has no add form, so click-to-edit there is out of scope. Open question for a follow-up: replace that page with a "load more" pattern in the widget.
- **JS-only enhancement.** No-JS users keep add / delete / Turn into draft as-is — they just don't get the edit affordance.

## Implementation notes

- The idea text is rendered as a `<button class="ideas-inbox__row-text">` so it's keyboard-activatable; native button styles are reset in CSS.
- Edit state is held in a closure inside `bindAddForm`. The Cancel button is injected from JS so it doesn't appear without JS.
- The PATCH endpoint reuses `ideas_inbox_render_row` and returns the updated row HTML, which the client swaps in place via `replaceWith`.
- Bumps version to `0.5.0`.

## Test plan

- [ ] Open the WordPress Playground preview link the bot will post on this PR.
- [ ] Add a few ideas, then click an idea's text — it loads into the textarea, button reads **Save**, **Cancel** appears.
- [ ] Edit and click **Save** — row updates in place, timestamp unchanged, form clears.
- [ ] Click **Cancel** mid-edit — textarea clears, button reverts to **Add idea**.
- [ ] Type a new idea, then click an existing idea — confirm discard prompt fires.
- [ ] In edit mode, type changes, then click another idea — confirm discard prompt fires.
- [ ] In edit mode, click the same idea again — no prompt; textarea stays focused.
- [ ] Disable JS — add/delete/draft still work; idea text is no longer interactive.
- [ ] Tab through the widget — focus reaches each idea's text with a visible focus ring; Enter/Space activates edit.